### PR TITLE
Add unit tests for member queries

### DIFF
--- a/Backend/tests/Application.UnitTests/Members/Queries/GetMemberDetailsQueryHandlerTests.cs
+++ b/Backend/tests/Application.UnitTests/Members/Queries/GetMemberDetailsQueryHandlerTests.cs
@@ -1,0 +1,95 @@
+using Afama.Go.Api.Application.Members.Queries.GetMemberDetails;
+using Afama.Go.Api.Domain.Entities;
+using Afama.Go.Api.Domain.Enums;
+using Afama.Go.Api.Infrastructure.Data;
+using Ardalis.GuardClauses;
+using AutoMapper;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using NUnit.Framework;
+
+namespace Afama.Go.Api.Application.UnitTests.Members.Queries;
+
+[TestFixture]
+public class GetMemberDetailsQueryHandlerTests
+{
+    private ApplicationDbContext _context;
+    private IMapper _mapper;
+    private GetMemberDetailsQueryHandler _handler;
+
+    [SetUp]
+    public void SetUp()
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .Options;
+        _context = new ApplicationDbContext(options);
+
+        var configuration = new MapperConfiguration(cfg =>
+        {
+            cfg.AddMaps(typeof(GetMemberDetailsQuery).Assembly);
+        });
+        _mapper = configuration.CreateMapper();
+
+        _handler = new GetMemberDetailsQueryHandler(_context, _mapper);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _context.Database.EnsureDeleted();
+        _context.Dispose();
+    }
+
+    [Test]
+    public async Task Handle_Should_Return_MemberDetailsDto_When_Member_Exists()
+    {
+        // Arrange
+        var member = new Member
+        {
+            Id = Guid.NewGuid(),
+            FirstName = "John",
+            LastName = "Doe",
+            Email = "john@example.com",
+            PhoneNumber = "+123",
+            MemberType = MemberType.Student,
+            BirthDate = new DateTime(1990, 1, 1),
+            Created = DateTimeOffset.UtcNow.AddDays(-10),
+            LastModified = DateTimeOffset.UtcNow.AddDays(-1)
+        };
+        _context.Members.Add(member);
+        await _context.SaveChangesAsync();
+
+        var query = new GetMemberDetailsQuery { MemberId = member.Id };
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        result.Should().BeEquivalentTo(new MemberDetailsDto
+        {
+            Id = member.Id,
+            FirstName = member.FirstName,
+            LastName = member.LastName,
+            Email = member.Email,
+            PhoneNumber = member.PhoneNumber,
+            MemberType = member.MemberType.ToString(),
+            BirthDate = member.BirthDate,
+            CreatedAt = member.Created,
+            UpdatedAt = member.LastModified
+        });
+    }
+
+    [Test]
+    public async Task Handle_Should_Throw_NotFoundException_When_Member_Not_Found()
+    {
+        // Arrange
+        var query = new GetMemberDetailsQuery { MemberId = Guid.NewGuid() };
+
+        // Act
+        var act = () => _handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<NotFoundException>();
+    }
+}

--- a/Backend/tests/Application.UnitTests/Members/Queries/GetMembersQueryHandlerTests.cs
+++ b/Backend/tests/Application.UnitTests/Members/Queries/GetMembersQueryHandlerTests.cs
@@ -107,4 +107,38 @@ public class GetMembersQueryHandlerTests
         // Assert
         result.Should().ContainSingle(m => m.LastName == "Smith");
     }
+
+    [Test]
+    public async Task Handle_Should_Return_All_Members_When_No_Filters()
+    {
+        // Arrange
+        _context.Members.AddRange(
+            new Member
+            {
+                Id = Guid.NewGuid(),
+                FirstName = "Alice",
+                LastName = "Smith",
+                Email = "alice@example.com",
+                PhoneNumber = "+123",
+                MemberType = MemberType.Student
+            },
+            new Member
+            {
+                Id = Guid.NewGuid(),
+                FirstName = "Bob",
+                LastName = "Jones",
+                Email = "bob@example.com",
+                PhoneNumber = "+456",
+                MemberType = MemberType.Student
+            });
+        await _context.SaveChangesAsync();
+
+        var query = new GetMembersQuery();
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        result.Should().HaveCount(2);
+    }
 }


### PR DESCRIPTION
## Summary
- add GetMemberDetails query handler unit tests
- cover GetMembers query handler when no filters are provided

## Testing
- `dotnet test` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68a72540bfcc8327b1a4985b3d69714c