### PR TITLE
Add update and delete member operations

### DIFF
--- a/Backend/src/Api.Host/DependencyInjection.cs
+++ b/Backend/src/Api.Host/DependencyInjection.cs
@@ -1,6 +1,8 @@
 ﻿using Afama.Go.Api.Application.Common.Interfaces;
 using Afama.Go.Api.Infrastructure.Data;
 using Afama.Go.Api.Host.Services;
+using Afama.Go.Api.Application.Members.Commands;
+using AutoMapper;
 using Azure.Identity;
 using Microsoft.AspNetCore.Mvc;
 
@@ -20,6 +22,7 @@ public static class DependencyInjection
             options.SuppressModelStateInvalidFilter = true);
 
         builder.Services.AddEndpointsApiExplorer();
+        builder.Services.AddAutoMapper(typeof(Program), typeof(CreateMemberCommand));
 
         builder.Services.AddOpenApiDocument((configure, sp) =>
         {

--- a/Backend/src/Api.Host/Endpoints/Members.cs
+++ b/Backend/src/Api.Host/Endpoints/Members.cs
@@ -14,7 +14,9 @@ public class Members : EndpointGroupBase
             .RequireAuthorization()
             .MapGet(GetMembers)
             .MapGet(GetMemberDetails, "{id}")
-            .MapPost(CreateMember);
+            .MapPost(CreateMember)
+            .MapPut(UpdateMember, "{id}")
+            .MapDelete(DeleteMember, "{id}");
     }
 
     public async Task<Ok<IEnumerable<MemberBriefDto>>> GetMembers(ISender sender, [AsParameters] GetMembersQuery query)
@@ -34,5 +36,18 @@ public class Members : EndpointGroupBase
     {
         var memberId = await sender.Send(command);
         return TypedResults.Created($"/{nameof(Members)}/{memberId}", memberId);
+    }
+
+    public async Task<Results<NoContent, NotFound>> UpdateMember(ISender sender, Guid id, UpdateMemberCommand command)
+    {
+        command = command with { Id = id };
+        await sender.Send(command);
+        return TypedResults.NoContent();
+    }
+
+    public async Task<Results<NoContent, NotFound>> DeleteMember(ISender sender, Guid id)
+    {
+        await sender.Send(new DeleteMemberCommand(id));
+        return TypedResults.NoContent();
     }
 }

--- a/Backend/src/Api.Host/wwwroot/api/specification.json
+++ b/Backend/src/Api.Host/wwwroot/api/specification.json
@@ -117,6 +117,58 @@
             "description": ""
           }
         }
+      },
+      "put": {
+        "operationId": "UpdateMember",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "guid"
+            },
+            "x-position": 1
+          }
+        ],
+        "requestBody": {
+          "x-name": "command",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateMemberCommand"
+              }
+            }
+          },
+          "required": true,
+          "x-position": 2
+        },
+        "responses": {
+          "204": {
+            "description": ""
+          }
+        }
+      },
+      "delete": {
+        "operationId": "DeleteMember",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "guid"
+            },
+            "x-position": 1
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": ""
+          }
+        }
       }
     }
   },
@@ -209,6 +261,40 @@
         "type": "object",
         "additionalProperties": false,
         "properties": {
+          "firstName": {
+            "type": "string"
+          },
+          "lastName": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string"
+          },
+          "phoneNumber": {
+            "type": "string"
+          },
+          "memberType": {
+            "$ref": "#/components/schemas/MemberType"
+          },
+          "birthDate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "knownPathologies": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "UpdateMemberCommand": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "guid"
+          },
           "firstName": {
             "type": "string"
           },

--- a/Backend/src/Application/Common/Mappings/MappingExtensions.cs
+++ b/Backend/src/Application/Common/Mappings/MappingExtensions.cs
@@ -1,6 +1,11 @@
-﻿using Afama.Go.Api.Application.Common.Models;
+using Afama.Go.Api.Application.Common.Models;
+using Afama.Go.Api.Domain.Common;
+using AutoMapper;
+using AutoMapper.QueryableExtensions;
+using Microsoft.EntityFrameworkCore;
 
 namespace Afama.Go.Api.Application.Common.Mappings;
+
 public static class MappingExtensions
 {
     public static Task<PaginatedList<TDestination>> PaginatedListAsync<TDestination>(this IQueryable<TDestination> queryable, int pageNumber, int pageSize) where TDestination : class
@@ -8,4 +13,17 @@ public static class MappingExtensions
 
     public static Task<List<TDestination>> ProjectToListAsync<TDestination>(this IQueryable queryable, IConfigurationProvider configuration) where TDestination : class
         => queryable.ProjectTo<TDestination>(configuration).AsNoTracking().ToListAsync();
+
+    public static IMappingExpression<TSource, TDestination> IgnoreAuditableEntity<TSource, TDestination>(this IMappingExpression<TSource, TDestination> mapping)
+        where TDestination : BaseAuditableEntity
+        => mapping
+            .ForMember(d => d.Id, opt => opt.Ignore())
+            .ForMember(d => d.Created, opt => opt.Ignore())
+            .ForMember(d => d.CreatedBy, opt => opt.Ignore())
+            .ForMember(d => d.LastModified, opt => opt.Ignore())
+            .ForMember(d => d.LastModifiedBy, opt => opt.Ignore())
+            .ForMember(d => d.IsDeleted, opt => opt.Ignore())
+            .ForMember(d => d.Deleted, opt => opt.Ignore())
+            .ForMember(d => d.DeletedBy, opt => opt.Ignore())
+            .ForMember(d => d.DomainEvents, opt => opt.Ignore());
 }

--- a/Backend/src/Application/Members/Commands/DeleteMemberCommand.cs
+++ b/Backend/src/Application/Members/Commands/DeleteMemberCommand.cs
@@ -1,0 +1,22 @@
+using Afama.Go.Api.Application.Common.Interfaces;
+using Afama.Go.Api.Domain.Entities;
+using Ardalis.GuardClauses;
+
+namespace Afama.Go.Api.Application.Members.Commands;
+
+public record DeleteMemberCommand(Guid Id) : IRequest;
+
+public class DeleteMemberCommandHandler(IApplicationDbContext context) : IRequestHandler<DeleteMemberCommand>
+{
+    public async Task Handle(DeleteMemberCommand request, CancellationToken cancellationToken)
+    {
+        var member = await context.Members.FindAsync(new object?[] { request.Id }, cancellationToken);
+        if (member == null)
+        {
+            throw new NotFoundException(nameof(Member), request.Id.ToString());
+        }
+
+        context.Members.Remove(member);
+        await context.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/Backend/src/Application/Members/Commands/DeleteMemberCommandValidator.cs
+++ b/Backend/src/Application/Members/Commands/DeleteMemberCommandValidator.cs
@@ -1,0 +1,10 @@
+namespace Afama.Go.Api.Application.Members.Commands;
+
+public class DeleteMemberCommandValidator : AbstractValidator<DeleteMemberCommand>
+{
+    public DeleteMemberCommandValidator()
+    {
+        RuleFor(x => x.Id)
+            .NotEmpty().WithMessage(string.Format(Translations.IsRequiredMessage, nameof(DeleteMemberCommand.Id)));
+    }
+}

--- a/Backend/src/Application/Members/Commands/UpdateMemberCommandValidator.cs
+++ b/Backend/src/Application/Members/Commands/UpdateMemberCommandValidator.cs
@@ -1,0 +1,48 @@
+namespace Afama.Go.Api.Application.Members.Commands;
+
+public class UpdateMemberCommandValidator : AbstractValidator<UpdateMemberCommand>
+{
+    public UpdateMemberCommandValidator()
+    {
+        RuleFor(x => x.Id)
+            .NotEmpty().WithMessage(string.Format(Translations.IsRequiredMessage, nameof(UpdateMemberCommand.Id)));
+
+        RuleFor(x => x.FirstName)
+            .NotEmpty().WithMessage(string.Format(Translations.IsRequiredMessage, nameof(UpdateMemberCommand.FirstName)))
+            .MaximumLength(64).WithMessage(string.Format(Translations.MustNotExceedCharactersMessage, nameof(UpdateMemberCommand.FirstName), 64));
+
+        RuleFor(x => x.LastName)
+            .NotEmpty().WithMessage(string.Format(Translations.IsRequiredMessage, nameof(UpdateMemberCommand.LastName)))
+            .MaximumLength(64).WithMessage(string.Format(Translations.MustNotExceedCharactersMessage, nameof(UpdateMemberCommand.LastName), 64));
+
+        RuleFor(x => x.Email)
+            .NotEmpty().WithMessage(string.Format(Translations.IsRequiredMessage, nameof(UpdateMemberCommand.Email)))
+            .EmailAddress().WithMessage(string.Format(Translations.EmailNotValidMessage, nameof(UpdateMemberCommand.Email)))
+            .MaximumLength(256).WithMessage(string.Format(Translations.MustNotExceedCharactersMessage, nameof(UpdateMemberCommand.Email), 256));
+
+        RuleFor(x => x.PhoneNumber)
+            .NotEmpty().WithMessage(string.Format(Translations.IsRequiredMessage, nameof(UpdateMemberCommand.PhoneNumber)))
+            .MaximumLength(48).WithMessage(string.Format(Translations.MustNotExceedCharactersMessage, nameof(UpdateMemberCommand.PhoneNumber), 48));
+
+        RuleFor(x => x.MemberType)
+            .Custom((value, context) =>
+            {
+                if (!Enum.IsDefined(value))
+                {
+                    context.AddFailure(string.Format(
+                        Translations.ValueNotValidMessage,
+                        value,
+                        nameof(UpdateMemberCommand.MemberType)
+                    ));
+                }
+            });
+
+        RuleFor(x => x.KnownPathologies)
+            .MaximumLength(2048).WithMessage(string.Format(Translations.MustNotExceedCharactersMessage, nameof(UpdateMemberCommand.KnownPathologies), 2048))
+            .When(x => !string.IsNullOrEmpty(x.KnownPathologies));
+
+        RuleFor(x => x.BirthDate)
+            .LessThan(DateTime.UtcNow).When(x => x.BirthDate.HasValue)
+            .WithMessage(string.Format(Translations.DateMustBeInPastMessage, nameof(UpdateMemberCommand.BirthDate)));
+    }
+}

--- a/Backend/tests/Application.UnitTests/Members/Commands/CreateMemberCommandHandlerTests.cs
+++ b/Backend/tests/Application.UnitTests/Members/Commands/CreateMemberCommandHandlerTests.cs
@@ -2,6 +2,7 @@ using Afama.Go.Api.Application.Common.Interfaces;
 using Afama.Go.Api.Application.Members.Commands;
 using Afama.Go.Api.Domain.Entities;
 using Afama.Go.Api.Domain.Enums;
+using AutoMapper;
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
 using Moq;
@@ -15,6 +16,7 @@ public class CreateMemberCommandHandlerTests
     private Mock<IApplicationDbContext> _mockContext;
     private Mock<DbSet<Member>> _mockMembersDbSet;
     private CreateMemberCommandHandler _handler;
+    private IMapper _mapper;
 
     [SetUp]
     public void SetUp()
@@ -26,7 +28,10 @@ public class CreateMemberCommandHandlerTests
         _mockContext.Setup(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()))
                    .ReturnsAsync(1);
 
-        _handler = new CreateMemberCommandHandler(_mockContext.Object);
+        var configuration = new MapperConfiguration(cfg => cfg.CreateMap<CreateMemberCommand, Member>());
+        _mapper = configuration.CreateMapper();
+
+        _handler = new CreateMemberCommandHandler(_mockContext.Object, _mapper);
     }
 
     [Test]

--- a/Backend/tests/Application.UnitTests/Members/Commands/DeleteMemberCommandHandlerTests.cs
+++ b/Backend/tests/Application.UnitTests/Members/Commands/DeleteMemberCommandHandlerTests.cs
@@ -1,0 +1,64 @@
+using Afama.Go.Api.Application.Members.Commands;
+using Afama.Go.Api.Domain.Entities;
+using Afama.Go.Api.Domain.Enums;
+using Afama.Go.Api.Infrastructure.Data;
+using Ardalis.GuardClauses;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using NUnit.Framework;
+
+namespace Afama.Go.Api.Application.UnitTests.Members.Commands;
+
+[TestFixture]
+public class DeleteMemberCommandHandlerTests
+{
+    private ApplicationDbContext _context;
+    private DeleteMemberCommandHandler _handler;
+
+    [SetUp]
+    public void SetUp()
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        _context = new ApplicationDbContext(options);
+        _handler = new DeleteMemberCommandHandler(_context);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _context.Database.EnsureDeleted();
+        _context.Dispose();
+    }
+
+    [Test]
+    public async Task Handle_Should_Delete_Member_When_Found()
+    {
+        var member = new Member
+        {
+            Id = Guid.NewGuid(),
+            FirstName = "Delete",
+            LastName = "Me",
+            Email = "delete@example.com",
+            PhoneNumber = "+789",
+            MemberType = MemberType.Student
+        };
+        _context.Members.Add(member);
+        await _context.SaveChangesAsync();
+
+        var command = new DeleteMemberCommand(member.Id);
+        await _handler.Handle(command, CancellationToken.None);
+
+        var deleted = await _context.Members.FindAsync(member.Id);
+        deleted.Should().BeNull();
+    }
+
+    [Test]
+    public async Task Handle_Should_Throw_NotFound_When_Member_Not_Exist()
+    {
+        var command = new DeleteMemberCommand(Guid.NewGuid());
+        var act = () => _handler.Handle(command, CancellationToken.None);
+        await act.Should().ThrowAsync<NotFoundException>();
+    }
+}

--- a/Backend/tests/Application.UnitTests/Members/Commands/DeleteMemberCommandHandlerTests.cs
+++ b/Backend/tests/Application.UnitTests/Members/Commands/DeleteMemberCommandHandlerTests.cs
@@ -55,7 +55,7 @@ public class DeleteMemberCommandHandlerTests
     }
 
     [Test]
-    public async Task Handle_Should_Throw_NotFound_When_Member_Not_Exist()
+    public async Task Handle_Should_Throw_NotFound_When_Member_Does_Not_Exist()
     {
         var command = new DeleteMemberCommand(Guid.NewGuid());
         var act = () => _handler.Handle(command, CancellationToken.None);

--- a/Backend/tests/Application.UnitTests/Members/Commands/DeleteMemberCommandValidatorTests.cs
+++ b/Backend/tests/Application.UnitTests/Members/Commands/DeleteMemberCommandValidatorTests.cs
@@ -1,0 +1,33 @@
+using Afama.Go.Api.Application.Members.Commands;
+using FluentValidation.TestHelper;
+using NUnit.Framework;
+
+namespace Afama.Go.Api.Application.UnitTests.Members.Commands;
+
+[TestFixture]
+public class DeleteMemberCommandValidatorTests
+{
+    private DeleteMemberCommandValidator _validator;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _validator = new DeleteMemberCommandValidator();
+    }
+
+    [Test]
+    public void Should_Have_Error_When_Id_Is_Empty()
+    {
+        var command = new DeleteMemberCommand(Guid.Empty);
+        var result = _validator.TestValidate(command);
+        result.ShouldHaveValidationErrorFor(x => x.Id);
+    }
+
+    [Test]
+    public void Should_Not_Have_Error_When_Id_Is_Provided()
+    {
+        var command = new DeleteMemberCommand(Guid.NewGuid());
+        var result = _validator.TestValidate(command);
+        result.ShouldNotHaveValidationErrorFor(x => x.Id);
+    }
+}

--- a/Backend/tests/Application.UnitTests/Members/Commands/UpdateMemberCommandHandlerTests.cs
+++ b/Backend/tests/Application.UnitTests/Members/Commands/UpdateMemberCommandHandlerTests.cs
@@ -1,0 +1,91 @@
+using Afama.Go.Api.Application.Members.Commands;
+using Afama.Go.Api.Domain.Entities;
+using Afama.Go.Api.Domain.Enums;
+using Afama.Go.Api.Infrastructure.Data;
+using Ardalis.GuardClauses;
+using AutoMapper;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using NUnit.Framework;
+
+namespace Afama.Go.Api.Application.UnitTests.Members.Commands;
+
+[TestFixture]
+public class UpdateMemberCommandHandlerTests
+{
+    private ApplicationDbContext _context;
+    private UpdateMemberCommandHandler _handler;
+    private IMapper _mapper;
+
+    [SetUp]
+    public void SetUp()
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        _context = new ApplicationDbContext(options);
+
+        var configuration = new MapperConfiguration(cfg =>
+            cfg.CreateMap<UpdateMemberCommand, Member>().ForMember(d => d.Id, opt => opt.Ignore()));
+        _mapper = configuration.CreateMapper();
+
+        _handler = new UpdateMemberCommandHandler(_context, _mapper);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _context.Database.EnsureDeleted();
+        _context.Dispose();
+    }
+
+    [Test]
+    public async Task Handle_Should_Update_Member_When_Found()
+    {
+        var member = new Member
+        {
+            Id = Guid.NewGuid(),
+            FirstName = "Old",
+            LastName = "Name",
+            Email = "old@example.com",
+            PhoneNumber = "+123",
+            MemberType = MemberType.Student
+        };
+        _context.Members.Add(member);
+        await _context.SaveChangesAsync();
+
+        var command = new UpdateMemberCommand
+        {
+            Id = member.Id,
+            FirstName = "New",
+            LastName = "Name",
+            Email = "new@example.com",
+            PhoneNumber = "+456",
+            MemberType = MemberType.Teacher
+        };
+
+        await _handler.Handle(command, CancellationToken.None);
+
+        var updated = await _context.Members.FindAsync(member.Id);
+        updated!.FirstName.Should().Be("New");
+        updated.Email.Should().Be("new@example.com");
+        updated.MemberType.Should().Be(MemberType.Teacher);
+    }
+
+    [Test]
+    public async Task Handle_Should_Throw_NotFound_When_Member_Does_Not_Exist()
+    {
+        var command = new UpdateMemberCommand
+        {
+            Id = Guid.NewGuid(),
+            FirstName = "Any",
+            LastName = "User",
+            Email = "a@b.com",
+            PhoneNumber = "+1",
+            MemberType = MemberType.Assistant
+        };
+
+        var act = () => _handler.Handle(command, CancellationToken.None);
+        await act.Should().ThrowAsync<NotFoundException>();
+    }
+}

--- a/Backend/tests/Application.UnitTests/Members/Commands/UpdateMemberCommandValidatorTests.cs
+++ b/Backend/tests/Application.UnitTests/Members/Commands/UpdateMemberCommandValidatorTests.cs
@@ -1,0 +1,271 @@
+using Afama.Go.Api.Application.Members.Commands;
+using Afama.Go.Api.Domain.Enums;
+using FluentValidation.TestHelper;
+using NUnit.Framework;
+
+namespace Afama.Go.Api.Application.UnitTests.Members.Commands;
+
+[TestFixture]
+public class UpdateMemberCommandValidatorTests
+{
+    private UpdateMemberCommandValidator _validator = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _validator = new UpdateMemberCommandValidator();
+    }
+
+    private static UpdateMemberCommand CreateValidCommand() => new()
+    {
+        Id = Guid.NewGuid(),
+        FirstName = "John",
+        LastName = "Doe",
+        Email = "john.doe@example.com",
+        PhoneNumber = "+1234567890",
+        MemberType = MemberType.Student,
+        BirthDate = DateTime.UtcNow.AddYears(-20),
+        KnownPathologies = "None"
+    };
+
+    [Test]
+    public void Should_Have_Error_When_Id_Is_Empty()
+    {
+        var command = CreateValidCommand() with { Id = Guid.Empty };
+        var result = _validator.TestValidate(command);
+        result.ShouldHaveValidationErrorFor(x => x.Id);
+    }
+
+    [Test]
+    public void Should_Not_Have_Error_When_Id_Is_Provided()
+    {
+        var command = CreateValidCommand();
+        var result = _validator.TestValidate(command);
+        result.ShouldNotHaveValidationErrorFor(x => x.Id);
+    }
+
+    [Test]
+    public void Should_Have_Error_When_FirstName_Is_Empty()
+    {
+        var command = CreateValidCommand() with { FirstName = string.Empty };
+        var result = _validator.TestValidate(command);
+        result.ShouldHaveValidationErrorFor(x => x.FirstName);
+    }
+
+    [Test]
+    public void Should_Have_Error_When_FirstName_Is_Null()
+    {
+        var command = CreateValidCommand();
+        command = command with { FirstName = null! };
+        var result = _validator.TestValidate(command);
+        result.ShouldHaveValidationErrorFor(x => x.FirstName);
+    }
+
+    [Test]
+    public void Should_Have_Error_When_FirstName_Exceeds_Maximum_Length()
+    {
+        var command = CreateValidCommand() with { FirstName = new string('a', 65) };
+        var result = _validator.TestValidate(command);
+        result.ShouldHaveValidationErrorFor(x => x.FirstName);
+    }
+
+    [Test]
+    public void Should_Not_Have_Error_When_FirstName_Is_Valid()
+    {
+        var command = CreateValidCommand();
+        var result = _validator.TestValidate(command);
+        result.ShouldNotHaveValidationErrorFor(x => x.FirstName);
+    }
+
+    [Test]
+    public void Should_Have_Error_When_LastName_Is_Empty()
+    {
+        var command = CreateValidCommand() with { LastName = string.Empty };
+        var result = _validator.TestValidate(command);
+        result.ShouldHaveValidationErrorFor(x => x.LastName);
+    }
+
+    [Test]
+    public void Should_Have_Error_When_LastName_Is_Null()
+    {
+        var command = CreateValidCommand();
+        command = command with { LastName = null! };
+        var result = _validator.TestValidate(command);
+        result.ShouldHaveValidationErrorFor(x => x.LastName);
+    }
+
+    [Test]
+    public void Should_Have_Error_When_LastName_Exceeds_Maximum_Length()
+    {
+        var command = CreateValidCommand() with { LastName = new string('a', 65) };
+        var result = _validator.TestValidate(command);
+        result.ShouldHaveValidationErrorFor(x => x.LastName);
+    }
+
+    [Test]
+    public void Should_Not_Have_Error_When_LastName_Is_Valid()
+    {
+        var command = CreateValidCommand();
+        var result = _validator.TestValidate(command);
+        result.ShouldNotHaveValidationErrorFor(x => x.LastName);
+    }
+
+    [Test]
+    public void Should_Have_Error_When_Email_Is_Empty()
+    {
+        var command = CreateValidCommand() with { Email = string.Empty };
+        var result = _validator.TestValidate(command);
+        result.ShouldHaveValidationErrorFor(x => x.Email);
+    }
+
+    [Test]
+    public void Should_Have_Error_When_Email_Is_Null()
+    {
+        var command = CreateValidCommand();
+        command = command with { Email = null! };
+        var result = _validator.TestValidate(command);
+        result.ShouldHaveValidationErrorFor(x => x.Email);
+    }
+
+    [Test]
+    public void Should_Have_Error_When_Email_Is_Invalid()
+    {
+        var command = CreateValidCommand() with { Email = "invalid" };
+        var result = _validator.TestValidate(command);
+        result.ShouldHaveValidationErrorFor(x => x.Email);
+    }
+
+    [Test]
+    public void Should_Have_Error_When_Email_Exceeds_Maximum_Length()
+    {
+        var longEmail = new string('a', 250) + "@test.com";
+        var command = CreateValidCommand() with { Email = longEmail };
+        var result = _validator.TestValidate(command);
+        result.ShouldHaveValidationErrorFor(x => x.Email);
+    }
+
+    [Test]
+    public void Should_Not_Have_Error_When_Email_Is_Valid()
+    {
+        var command = CreateValidCommand();
+        var result = _validator.TestValidate(command);
+        result.ShouldNotHaveValidationErrorFor(x => x.Email);
+    }
+
+    [Test]
+    public void Should_Have_Error_When_PhoneNumber_Is_Empty()
+    {
+        var command = CreateValidCommand() with { PhoneNumber = string.Empty };
+        var result = _validator.TestValidate(command);
+        result.ShouldHaveValidationErrorFor(x => x.PhoneNumber);
+    }
+
+    [Test]
+    public void Should_Have_Error_When_PhoneNumber_Is_Null()
+    {
+        var command = CreateValidCommand();
+        command = command with { PhoneNumber = null! };
+        var result = _validator.TestValidate(command);
+        result.ShouldHaveValidationErrorFor(x => x.PhoneNumber);
+    }
+
+    [Test]
+    public void Should_Have_Error_When_PhoneNumber_Exceeds_Maximum_Length()
+    {
+        var command = CreateValidCommand() with { PhoneNumber = new string('1', 49) };
+        var result = _validator.TestValidate(command);
+        result.ShouldHaveValidationErrorFor(x => x.PhoneNumber);
+    }
+
+    [Test]
+    public void Should_Not_Have_Error_When_PhoneNumber_Is_Valid()
+    {
+        var command = CreateValidCommand();
+        var result = _validator.TestValidate(command);
+        result.ShouldNotHaveValidationErrorFor(x => x.PhoneNumber);
+    }
+
+    [Test]
+    public void Should_Have_Error_When_MemberType_Is_Invalid()
+    {
+        var command = CreateValidCommand() with { MemberType = (MemberType)999 };
+        var result = _validator.TestValidate(command);
+        result.ShouldHaveValidationErrorFor(x => x.MemberType);
+    }
+
+    [TestCase(MemberType.Student)]
+    [TestCase(MemberType.Assistant)]
+    [TestCase(MemberType.Teacher)]
+    [TestCase(MemberType.Parent)]
+    [TestCase(MemberType.Other)]
+    public void Should_Not_Have_Error_When_MemberType_Is_Valid(MemberType memberType)
+    {
+        var command = CreateValidCommand() with { MemberType = memberType };
+        var result = _validator.TestValidate(command);
+        result.ShouldNotHaveValidationErrorFor(x => x.MemberType);
+    }
+
+    [Test]
+    public void Should_Have_Error_When_KnownPathologies_Exceeds_Maximum_Length()
+    {
+        var command = CreateValidCommand() with { KnownPathologies = new string('a', 2049) };
+        var result = _validator.TestValidate(command);
+        result.ShouldHaveValidationErrorFor(x => x.KnownPathologies);
+    }
+
+    [Test]
+    public void Should_Not_Have_Error_When_KnownPathologies_Is_Valid_Length()
+    {
+        var command = CreateValidCommand() with { KnownPathologies = new string('a', 2048) };
+        var result = _validator.TestValidate(command);
+        result.ShouldNotHaveValidationErrorFor(x => x.KnownPathologies);
+    }
+
+    [Test]
+    public void Should_Not_Have_Error_When_KnownPathologies_Is_Null()
+    {
+        var command = CreateValidCommand() with { KnownPathologies = null };
+        var result = _validator.TestValidate(command);
+        result.ShouldNotHaveValidationErrorFor(x => x.KnownPathologies);
+    }
+
+    [Test]
+    public void Should_Not_Have_Error_When_KnownPathologies_Is_Empty()
+    {
+        var command = CreateValidCommand() with { KnownPathologies = string.Empty };
+        var result = _validator.TestValidate(command);
+        result.ShouldNotHaveValidationErrorFor(x => x.KnownPathologies);
+    }
+
+    [Test]
+    public void Should_Have_Error_When_BirthDate_Is_In_Future()
+    {
+        var command = CreateValidCommand() with { BirthDate = DateTime.UtcNow.AddDays(1) };
+        var result = _validator.TestValidate(command);
+        result.ShouldHaveValidationErrorFor(x => x.BirthDate);
+    }
+
+    [Test]
+    public void Should_Not_Have_Error_When_BirthDate_Is_In_Past()
+    {
+        var command = CreateValidCommand() with { BirthDate = DateTime.UtcNow.AddYears(-30) };
+        var result = _validator.TestValidate(command);
+        result.ShouldNotHaveValidationErrorFor(x => x.BirthDate);
+    }
+
+    [Test]
+    public void Should_Not_Have_Error_When_BirthDate_Is_Null()
+    {
+        var command = CreateValidCommand() with { BirthDate = null };
+        var result = _validator.TestValidate(command);
+        result.ShouldNotHaveValidationErrorFor(x => x.BirthDate);
+    }
+
+    [Test]
+    public void Should_Pass_Validation_When_All_Properties_Are_Valid()
+    {
+        var command = CreateValidCommand();
+        var result = _validator.TestValidate(command);
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+}


### PR DESCRIPTION
## Summary
- map members endpoints to application commands without intermediate request DTOs
- describe CreateMemberCommand and UpdateMemberCommand payloads in the generated API specification
- update members endpoint unit tests to post commands directly
- factor common auditing property ignores into a reusable AutoMapper extension

## Testing
- `dotnet build Backend/src/Api.Host/Api.Host.csproj`
- `dotnet test Backend/Afama.Go.Api.sln`


------
https://chatgpt.com/codex/tasks/task_e_68a74f5cb5d88327b58b7ae5088a9cd3