### PR TITLE
Add unit tests for domain base and entity classes

### DIFF
--- a/Backend/tests/Domain.UnitTests/Common/BaseEntityTests.cs
+++ b/Backend/tests/Domain.UnitTests/Common/BaseEntityTests.cs
@@ -1,0 +1,47 @@
+using Afama.Go.Api.Domain.Common;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Afama.Go.Api.Domain.UnitTests.Common;
+
+public class BaseEntityTests
+{
+    private class TestEntity : BaseEntity { }
+
+    private class TestDomainEvent : BaseEvent { }
+
+    [Test]
+    public void AddDomainEvent_ShouldAddEvent()
+    {
+        var entity = new TestEntity();
+        var domainEvent = new TestDomainEvent();
+
+        entity.AddDomainEvent(domainEvent);
+
+        entity.DomainEvents.Should().ContainSingle().Which.Should().Be(domainEvent);
+    }
+
+    [Test]
+    public void RemoveDomainEvent_ShouldRemoveEvent()
+    {
+        var entity = new TestEntity();
+        var domainEvent = new TestDomainEvent();
+        entity.AddDomainEvent(domainEvent);
+
+        entity.RemoveDomainEvent(domainEvent);
+
+        entity.DomainEvents.Should().BeEmpty();
+    }
+
+    [Test]
+    public void ClearDomainEvents_ShouldClearEvents()
+    {
+        var entity = new TestEntity();
+        entity.AddDomainEvent(new TestDomainEvent());
+        entity.AddDomainEvent(new TestDomainEvent());
+
+        entity.ClearDomainEvents();
+
+        entity.DomainEvents.Should().BeEmpty();
+    }
+}

--- a/Backend/tests/Domain.UnitTests/Entities/ClubTests.cs
+++ b/Backend/tests/Domain.UnitTests/Entities/ClubTests.cs
@@ -1,0 +1,17 @@
+using Afama.Go.Api.Domain.Entities;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Afama.Go.Api.Domain.UnitTests.Entities;
+
+public class ClubTests
+{
+    [Test]
+    public void Constructor_ShouldInitializeCollections()
+    {
+        var club = new Club();
+
+        club.Courses.Should().NotBeNull().And.BeEmpty();
+        club.Members.Should().NotBeNull().And.BeEmpty();
+    }
+}

--- a/Backend/tests/Domain.UnitTests/Entities/CourseTeacherTests.cs
+++ b/Backend/tests/Domain.UnitTests/Entities/CourseTeacherTests.cs
@@ -1,0 +1,17 @@
+using Afama.Go.Api.Domain.Entities;
+using Afama.Go.Api.Domain.Enums;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Afama.Go.Api.Domain.UnitTests.Entities;
+
+public class CourseTeacherTests
+{
+    [Test]
+    public void CourseTeacherType_ShouldDefaultToMain()
+    {
+        var teacher = new CourseTeacher();
+
+        teacher.CourseTeacherType.Should().Be(CourseTeacherType.Main);
+    }
+}

--- a/Backend/tests/Domain.UnitTests/Entities/CourseTests.cs
+++ b/Backend/tests/Domain.UnitTests/Entities/CourseTests.cs
@@ -1,0 +1,16 @@
+using Afama.Go.Api.Domain.Entities;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Afama.Go.Api.Domain.UnitTests.Entities;
+
+public class CourseTests
+{
+    [Test]
+    public void Constructor_ShouldInitializeCollections()
+    {
+        var course = new Course();
+
+        course.Teachers.Should().NotBeNull().And.BeEmpty();
+    }
+}

--- a/Backend/tests/Domain.UnitTests/Entities/MemberTests.cs
+++ b/Backend/tests/Domain.UnitTests/Entities/MemberTests.cs
@@ -1,0 +1,25 @@
+using Afama.Go.Api.Domain.Entities;
+using Afama.Go.Api.Domain.Enums;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Afama.Go.Api.Domain.UnitTests.Entities;
+
+public class MemberTests
+{
+    [Test]
+    public void Constructor_ShouldInitializeCollections()
+    {
+        var member = new Member();
+
+        member.Clubs.Should().NotBeNull().And.BeEmpty();
+    }
+
+    [Test]
+    public void MemberType_ShouldDefaultToStudent()
+    {
+        var member = new Member();
+
+        member.MemberType.Should().Be(MemberType.Student);
+    }
+}

--- a/Backend/tests/Domain.UnitTests/ValueObjects/TestValueObjectTests.cs
+++ b/Backend/tests/Domain.UnitTests/ValueObjects/TestValueObjectTests.cs
@@ -1,0 +1,53 @@
+using Afama.Go.Api.Domain.Common;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Afama.Go.Api.Domain.UnitTests.ValueObjects;
+
+public class TestValueObjectTests
+{
+    private class TestValueObject : ValueObject
+    {
+        public string Name { get; }
+        public int Amount { get; }
+
+        public TestValueObject(string name, int amount)
+        {
+            Name = name;
+            Amount = amount;
+        }
+
+        protected override IEnumerable<object> GetEqualityComponents()
+        {
+            yield return Name;
+            yield return Amount;
+        }
+
+        public static bool operator ==(TestValueObject? left, TestValueObject? right) => EqualOperator(left!, right!);
+        public static bool operator !=(TestValueObject? left, TestValueObject? right) => NotEqualOperator(left!, right!);
+
+        public override bool Equals(object? obj) => base.Equals(obj);
+        public override int GetHashCode() => base.GetHashCode();
+    }
+
+    [Test]
+    public void ValueObjects_WithSameValues_ShouldBeEqual()
+    {
+        var first = new TestValueObject("Item", 1);
+        var second = new TestValueObject("Item", 1);
+
+        first.Should().Be(second);
+        (first == second).Should().BeTrue();
+        first.GetHashCode().Should().Be(second.GetHashCode());
+    }
+
+    [Test]
+    public void ValueObjects_WithDifferentValues_ShouldNotBeEqual()
+    {
+        var first = new TestValueObject("Item", 1);
+        var second = new TestValueObject("Item", 2);
+
+        first.Should().NotBe(second);
+        (first != second).Should().BeTrue();
+    }
+}


### PR DESCRIPTION
## Summary
- add coverage for BaseEntity domain event methods
- verify ValueObject equality behaviors with a sample value object
- ensure domain entities initialize navigation collections and default enum values

## Testing
- `dotnet test Backend/tests/Domain.UnitTests/Domain.UnitTests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a8ead81b548327a9c7944a93955f6b